### PR TITLE
set package.json main to lib/react/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Overlay component for pigeon-maps",
   "author": "Marius Andra",
   "license": "MIT",
-  "main": "lib/index.js",
+  "main": "lib/react/index.js",
   "jsnext:main": "src/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
this fix is necessary for import statements to work like:

```
import Overlay from 'pigeon-overlay'
```

Before this fix I'm getting following error when building:

```
Module not found: Error: Cannot resolve module 'pigeon-overlay'
```