### PR TITLE
styles - Add `style` props to Overlay component for easy overload

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -13,7 +13,7 @@ export default class Demo extends Component {
              zoom={12}
              width={600}
              height={400}>
-          <Overlay anchor={[50.879, 4.6997]} offset={[60, 39]}>
+          <Overlay anchor={[50.879, 4.6997]} offset={[60, 39]} style={{border: '1px solid red'}}>
             <img src={pigeon} width={120} height={79} alt='' />
           </Overlay>
         </Map>

--- a/src/index.js
+++ b/src/index.js
@@ -22,10 +22,10 @@ export default class Overlay extends Component {
   // render
 
   render () {
-    const { left, top, className } = this.props
+    const { left, top, className, style = {} } = this.props
 
     return (
-      <div style={{ position: 'absolute', transform: `translate(${left}px, ${top}px)` }} className={className || ''}>
+      <div style={{ position: 'absolute', transform: `translate(${left}px, ${top}px)`, ...style }} className={className || ''}>
         {this.props.children}
       </div>
     )


### PR DESCRIPTION
While this may looks like a basic features, it will allow people are using css-in-js kind of stylesheets to more easily overload the style of the overlay. 

For instance, my app was using [styled-components](https://www.styled-components.com/) so there is no any css file in the whole, it makes more sense to simply set `style` prop.